### PR TITLE
React: Disable no-multi-comp

### DIFF
--- a/react.js
+++ b/react.js
@@ -51,7 +51,7 @@ module.exports = {
 		"react/no-direct-mutation-state": "error",
 		"react/no-find-dom-node": "error",
 		"react/no-is-mounted": "error",
-		"react/no-multi-comp": "error",
+		"react/no-multi-comp": "off",
 		"react/no-render-return-value": "error",
 		"react/no-set-state": "off",
 		"react/no-string-refs": "off",


### PR DESCRIPTION
There are plenty of valid use cases that have multiple React components in a single file. Rely on good taste instead.